### PR TITLE
fix: handle invalid imageURL

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,8 +13,12 @@ export const isWhitelistedImage = (imageURL) => {
     'miro.medium.com'
   ]
 
-  const { hostname }= new URL(imageURL)
-  return whitelist.includes(hostname)
+  try {
+    const { hostname }= new URL(imageURL)
+    return whitelist.includes(hostname)
+  } catch (e) {
+    return false
+  }
 }
 
 export const classNames = (...classes) => {


### PR DESCRIPTION
There are some invalid URL like this one in NFTCatalog...

<img width="505" alt="WechatIMG345" src="https://user-images.githubusercontent.com/10380321/190882178-ea8bbf4d-1cb4-4f0a-a148-2774866bbb83.png">
