### PR TITLE
fix: smaller bulk size

### DIFF
--- a/flow/scripts.js
+++ b/flow/scripts.js
@@ -264,7 +264,9 @@ const splitList = (list, chunkSize) => {
 // --- NFT Catalog ---
 
 export const bulkGetNftCatalog = async () => {
-  const collectionIdentifiers = await getCollectionIdentifiers()
+  const collectionIdentifiers = (await getCollectionIdentifiers()).filter((c) => {
+    return c != "Gamisodes"
+  })
   const groups = splitList(collectionIdentifiers, 50)
   const promises = groups.map((group) => {
     return getNftCatalogByCollectionIDs(group)

--- a/flow/scripts.js
+++ b/flow/scripts.js
@@ -51,7 +51,7 @@ const splitCatalog = (catalog) => {
   const catalogs = []
   let currentCatalog = {}
   for (const [catalogName, metadata] of Object.entries(catalog)) {
-    if (Object.keys(currentCatalog).length >= 40) {
+    if (Object.keys(currentCatalog).length >= 35) {
       const c = Object.assign({}, currentCatalog)
       catalogs.push(c)
       currentCatalog = {}
@@ -264,9 +264,7 @@ const splitList = (list, chunkSize) => {
 // --- NFT Catalog ---
 
 export const bulkGetNftCatalog = async () => {
-  const collectionIdentifiers = (await getCollectionIdentifiers()).filter((c) => {
-    return c != "Gamisodes"
-  })
+  const collectionIdentifiers = await getCollectionIdentifiers()
   const groups = splitList(collectionIdentifiers, 50)
   const promises = groups.map((group) => {
     return getNftCatalogByCollectionIDs(group)


### PR DESCRIPTION
It's strange, checking the link status in bulk with size 40 is works well before, but now it's kind of broken: if Gamisodes not in the bulk group, it works fine, otherwise it will raise a max interaction limit error🤣 . 